### PR TITLE
Add mapOnUpdate option to mapBacked method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'signing'
-    id 'org.openjfx.javafxplugin' version '0.0.13'
+    id 'org.openjfx.javafxplugin' version '0.1.0'
     id 'org.hibernate.build.maven-repo-auth' version '3.0.3'
     id 'org.javamodularity.moduleplugin' version '1.8.15'
     id 'io.codearte.nexus-staging' version '0.30.0'

--- a/src/main/java/com/tobiasdiez/easybind/EasyBind.java
+++ b/src/main/java/com/tobiasdiez/easybind/EasyBind.java
@@ -307,13 +307,22 @@ public class EasyBind {
     /**
      * Creates a new list in which each element is converted using the provided mapping.
      * All changes to the underlying list are propagated to the converted list.
+     * If the change event indicates that an item was updated, as determined by {@link ListChangeListener.Change#wasUpdated()},
+     * the mapping function is called again to create a new object reflecting the updated value.
      * <p>
      * In contrast to {@link #map(ObservableList, Function)},
-     * the items are converted when the are inserted instead of when they are accessed.
-     * Thus the initial CPU overhead and memory consumption is higher but the access to list items is quicker.
+     * the items are converted when they are inserted instead of when they are accessed.
+     * Thus, the initial CPU overhead and memory consumption is higher but the access to list items is quicker.
      */
     public static <A, B> EasyObservableList<B> mapBacked(ObservableList<A> source, Function<A, B> mapper) {
-        return new MappedBackedList<>(source, mapper);
+        return new MappedBackedList<>(source, mapper, true);
+    }
+
+    /**
+     * Similar to {@link #mapBacked(ObservableList, Function)}, but allows specifying if the mapping should be done on update.
+     */
+    public static <A, B> EasyObservableList<B> mapBacked(ObservableList<A> source, Function<A, B> mapper, boolean mapOnUpdate) {
+        return new MappedBackedList<>(source, mapper, mapOnUpdate);
     }
 
     public static <A, B, R> EasyBinding<R> combine(ObservableValue<A> src1, ObservableValue<B> src2, BiFunction<A, B, R> f) {

--- a/src/main/java/com/tobiasdiez/easybind/MappedBackedList.java
+++ b/src/main/java/com/tobiasdiez/easybind/MappedBackedList.java
@@ -11,10 +11,12 @@ class MappedBackedList<E, F> extends TransformationList<E, F> implements EasyObs
 
     private final Function<F, E> mapper;
     private final List<E> backingList;
+    private final boolean mapOnUpdate;
 
-    public MappedBackedList(ObservableList<? extends F> sourceList, Function<F, E> mapper) {
+    public MappedBackedList(ObservableList<? extends F> sourceList, Function<F, E> mapper, boolean mapOnUpdate) {
         super(sourceList);
         this.mapper = mapper;
+        this.mapOnUpdate = mapOnUpdate;
         this.backingList = new ArrayList<>(sourceList.size());
         sourceList.stream().map(mapper).forEach(backingList::add);
     }
@@ -45,7 +47,9 @@ class MappedBackedList<E, F> extends TransformationList<E, F> implements EasyObs
                 }
                 nextPermutation(from, to, permutation);
             } else if (change.wasUpdated()) {
-                backingList.set(change.getFrom(), mapper.apply(getSource().get(change.getFrom())));
+                if (mapOnUpdate) {
+                    backingList.set(change.getFrom(), mapper.apply(getSource().get(change.getFrom())));
+                }
                 nextUpdate(change.getFrom());
             } else {
                 if (change.wasRemoved()) {


### PR DESCRIPTION
Creating a new object on update may not always be needed, especially if the object has bindings that already reflect changes in the mapped object.
